### PR TITLE
autocc.py: Fix generated port lists that end with comment

### DIFF
--- a/autocc.py
+++ b/autocc.py
@@ -482,6 +482,8 @@ def write_line(prop, line):
         if not any(x in line for x in keywords):
             if "," in line:
                 prop.write("\t\t" + line.split(",")[0] + "_2,\n")
+            elif "//" in line:
+                prop.write("\t\t" + line.split("//")[0].strip() + "_2,\n")
             else:
                 prop.write("\t\t" + line.split("\n")[0] + "_2,\n")
     prop.write("\t\t" + line)


### PR DESCRIPTION
For the last port of a DUT, autocc currently appends `_2,` at the end of the line. However, if the line ends on a comment, the `_2,` suffix is appended *behind* the comment instead of the variable name, causing syntax errors. In particular, this affects port lists ending with an output, since autocc appends `\\output` after those. Fix this by inserting the suffix in lines that contain a comment but no comma (last port) *before* the comment.