### PR TITLE
autocc.py: Support local imports

### DIFF
--- a/autocc.py
+++ b/autocc.py
@@ -465,7 +465,7 @@ def create_wrapper(rtl, wrap):
                     wrap.write("\t\t" + line)
                 annotation = None
 
-        elif not parsed_module_sec:
+        elif not parsed_module_sec or line.startswith("import"):
             if (not parsed_disclaimer_sec) and (not line.startswith("//")):
                 parsed_disclaimer_sec = True
                 gen_disclaimer(wrap,True)
@@ -589,7 +589,7 @@ def parse_global(rtl, prop, bind):
                     prop.write("\t\t" + line)
                 annotation = None
 
-        elif not parsed_module_sec:
+        elif not parsed_module_sec or line.startswith("import"):
             if (not parsed_disclaimer_sec) and (not line.startswith("//")):
                 parsed_disclaimer_sec = True
                 gen_disclaimer(prop,True)


### PR DESCRIPTION
Some modules use local imports, e.g. [axi_xbar](https://github.com/pulp-platform/axi/blob/4e54ac6766b160217a83a74d5a23af9bbf59e6ee/src/axi_xbar.sv#L19). Copy the corresponding lines to the prop/wrap files to make them available there.